### PR TITLE
Set proper hostname for local connections.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ LMIWBEM has several dependencies:
 - tog-pegasus-libs (2.12.0)
 - boost-python (1.50.0)
 - python-devel
+- openslp-devel
 - build tools (autoconf, automake, make, ...)
 
 LMIWBEM supports 2 build systems:

--- a/src/lmiwbem_client.cpp
+++ b/src/lmiwbem_client.cpp
@@ -93,6 +93,7 @@ void CIMClient::connectLocally()
 {
     Pegasus::CIMClient::connectLocal();
     m_is_connected = true;
+    m_url_info.set("localhost");
 }
 
 void CIMClient::disconnect()

--- a/src/lmiwbem_urlinfo.cpp
+++ b/src/lmiwbem_urlinfo.cpp
@@ -22,24 +22,82 @@
 #include <config.h>
 #include <cerrno>
 #include <sstream>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netdb.h>
+#include <unistd.h>
+#include <string.h>
 #include "lmiwbem_urlinfo.h"
 
+namespace {
+    const unsigned int BUFLEN = 1024;
+
+    Pegasus::String get_fqdn() {
+        struct addrinfo hints, *info, *p;
+        int gai_result;
+        char name[BUFLEN + 1];
+        char port[BUFLEN];
+
+        if (gethostname(name, BUFLEN) < 0) {
+            return Pegasus::String("localhost");
+        }
+
+        memset(&hints, 0, sizeof hints);
+        hints.ai_family = AF_UNSPEC; /*either IPV4 or IPV6*/
+        hints.ai_socktype = SOCK_STREAM;
+        hints.ai_flags = AI_CANONNAME;
+
+        snprintf(port, BUFLEN, "%d", URLInfo::DEF_HTTPS_PORT);
+        if ((gai_result = getaddrinfo(name, port, &hints, &info)) == 0) {
+            for (p = info; p != NULL; p = p->ai_next) {
+                if (p->ai_canonname != NULL) {
+                    snprintf(name, BUFLEN, p->ai_canonname);
+                    break;
+                }
+            }
+            freeaddrinfo(info);
+        }
+        return Pegasus::String(name);
+    }
+}
+
 URLInfo::URLInfo()
-    : m_hostname("unknown")
+    : m_url("https://unknown")
+    , m_hostname("unknown")
     , m_port(URLInfo::DEF_HTTPS_PORT)
     , m_is_https(true)
+    , m_is_local(false)
 {
 }
 
 URLInfo::URLInfo(const URLInfo &copy)
-    : m_hostname(copy.m_hostname)
+    : m_url(copy.m_url)
+    , m_hostname(copy.m_hostname)
     , m_port(copy.m_port)
     , m_is_https(copy.m_is_https)
+    , m_is_local(copy.m_is_local)
 {
 }
 
 bool URLInfo::set(Pegasus::String url)
 {
+    m_url = url;
+    /* Handle local connection */
+    if (url.subString(0, 7) == "file://" ||
+            url == "localhost" ||
+            url == "localhost.localdomain" ||
+            url == "localhost4" ||
+            url == "localhost4.localdomain4" ||
+            url == "localhost6" ||
+            url == "localhost6.localdomain6" ||
+            url == "127.0.0.1" || url == "::1") {
+        m_is_https = false;
+        m_is_local = true;
+        m_hostname = get_fqdn();
+        m_port = 0;
+        return true;
+    }
+    /* Handle remote connection */
     if (url.subString(0, 7) == "http://") {
         url.remove(0, 7);
         m_port = URLInfo::DEF_HTTP_PORT;

--- a/src/lmiwbem_urlinfo.h
+++ b/src/lmiwbem_urlinfo.h
@@ -28,27 +28,31 @@
 class URLInfo
 {
 public:
+    static const Pegasus::Uint32 DEF_HTTPS_PORT = 5989;
+    static const Pegasus::Uint32 DEF_HTTP_PORT  = 5988;
+
     URLInfo();
     URLInfo(const URLInfo &copy);
 
     bool set(Pegasus::String url);
 
+    Pegasus::String url() const { return m_url; }
     Pegasus::String hostname() const { return m_hostname; }
     Pegasus::Uint32 port() const { return m_port; }
 
     bool isHttps() const { return m_is_https; }
+    bool isLocal() const { return m_is_local; }
 
     std::string asStdString() const;
 
     URLInfo &operator =(const URLInfo &rhs);
 
 private:
-    static const Pegasus::Uint32 DEF_HTTPS_PORT = 5989;
-    static const Pegasus::Uint32 DEF_HTTP_PORT  = 5988;
-
+    Pegasus::String m_url;
     Pegasus::String m_hostname;
     Pegasus::Uint32 m_port;
     bool m_is_https;
+    bool m_is_local;
 };
 
 #endif // WBEM_CLIENT_ADDRESS_H


### PR DESCRIPTION
LMIShell uses this value for creating indication filter and handler instances. With `"unknown"` hostname this results in similar errors:

```
Traceback (most recent call last):
  File "/root/workspace/openlmi-tools/cli/lmi/scripts/common/command/checkresult.py", line 99, in take_action
    result = self.execute_on_connection(connection, *args, **kwargs)
  File "/root/workspace/openlmi-tools/cli/lmi/scripts/common/command/session.py", line 205, in execute_on_connection
    return self.execute(connection, *args, **kwargs)
  File "/root/workspace/openlmi-tools/cli/lmi/scripts/common/command/meta.py", line 110, in _execute
    return func(__connection__, *args, **kwargs)
  File "/root/workspace/openlmi-scripts/commands/journald/lmi/scripts/journald/__init__.py", line 118, in watch
    ret = ns.connection.subscribe_indication(
  File "/root/workspace/openlmi-tools/cli/lmi/shell/LMIConnection.py", line 531, in subscribe_indication
    cim_subscription_props)
  File "/root/workspace/openlmi-tools/cli/lmi/shell/LMIDecorators.py", line 319, in wrapped
    lmi_raise_or_dump_exception(cim_error)
  File "/root/workspace/openlmi-tools/cli/lmi/shell/LMIDecorators.py", line 316, in wrapped
    rval = fn(*args, **kwargs)
  File "/root/workspace/openlmi-tools/cli/lmi/shell/LMICIMXMLClient.py", line 754, in create_instance
    cim_path = self._cliconn.CreateInstance(NewInstance=cim_instance)
CIMError: (4, 'CreateInstance: CIM_ERR_INVALID_PARAMETER: The value //unknown/root/interop:CIM_IndicationFilter.CreationClassName="CIM_IndicationFilter",Name="lmiscript_journald_watch-7E9109R8-filter",SystemCreationClassName="CIM_ComputerSystem",SystemName="kvm-rawhide-lmi.virbr0" is not valid for property Filter.')
```

Note the `//unknown/root/interop` part. Once it's replaced with correct
hostname, the subscription works.
