### PR TITLE
Avoid overflow error for large int on 64-bit

### DIFF
--- a/src/obj/cim/lmiwbem_value.cpp
+++ b/src/obj/cim/lmiwbem_value.cpp
@@ -274,7 +274,10 @@ Pegasus::CIMValue CIMValue::asPegasusCIMValue(
         return setPegasusValueS<bool>(value, is_array);
 #  if PY_MAJOR_VERSION < 3
     } else if (isint(py_value_type_check)) {
-        return setPegasusValueS<Pegasus::Sint32>(value, is_array);
+        if (sizeof(long) == sizeof(Pegasus::Sint32)) {
+            return setPegasusValueS<Pegasus::Sint32>(value, is_array);
+        }
+        return setPegasusValueS<Pegasus::Sint64>(value, is_array);
 #  endif // PY_MAJOR_VERSION
     } else if (islong(py_value_type_check)) {
         return setPegasusValueS<Pegasus::Sint64>(value, is_array);


### PR DESCRIPTION
When passing large integer to some method (e.g. size=10_1000_1000*1000) I get an exception:
OverflowError: bad numeric conversion: positive overflow

The error caused by conversion long to sint32 value. Python's int is long in C and has 64-bit width on 64-bit platform, so it can't be converted to int32.
